### PR TITLE
Use constexpr for compile-time constants

### DIFF
--- a/src/Application/Application.h
+++ b/src/Application/Application.h
@@ -36,7 +36,7 @@ public:
 	{	
 		Keypad& keypad = mController->GetKeypad();
 
-		const std::array<std::pair<uint8_t, olc::Key>, 16> defaultBindings = { {
+                constexpr std::array<std::pair<uint8_t, olc::Key>, 16> defaultBindings = { {
 			{ Key::Key1, olc::Key::K1 },
 			{ Key::Key2, olc::Key::K2 },
 			{ Key::Key3, olc::Key::K3 },

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -63,7 +63,7 @@ StepResult Interpreter::Step()
 		is rolled back to retry the same instruction.
 	*/
 
-	const bool kHaltOnFailure = true;
+	constexpr bool kHaltOnFailure = true;
 	const uint16_t pcBeforeFetch = mCPU.GetProgramCounter();
 
 	// Fetch (increments PC)
@@ -87,7 +87,7 @@ StepResult Interpreter::Step()
 		
 	if (status != ExecutionStatus::Executed)
 	{
-		// Instruction failed or deferred — rollback PC to preserve CPU state
+		// Instruction failed or deferred â€” rollback PC to preserve CPU state
 		mCPU.SetProgramCounter(pcBeforeFetch);
 	}
 

--- a/src/UI/UIManager.h
+++ b/src/UI/UIManager.h
@@ -96,8 +96,8 @@ public:
 private:
 	void LayoutTopWidgets()
 	{
-		const int32_t contentWidth = SCREEN_WIDTH - UITheme::kWidgetSpacing * 2;
-		const olc::vi2d contentStart{ UITheme::kWidgetSpacing, UITheme::kWidgetSpacing };
+                constexpr int32_t contentWidth = SCREEN_WIDTH - UITheme::kWidgetSpacing * 2;
+                constexpr olc::vi2d contentStart{ UITheme::kWidgetSpacing, UITheme::kWidgetSpacing };
 
 		const int32_t controlsX = (contentWidth - mControlsWidget.GetSize().mX) / 2;
 		const olc::vi2d controlsPosition{ controlsX, 0 };

--- a/src/UI/Widgets/DisplayWidget.h
+++ b/src/UI/Widgets/DisplayWidget.h
@@ -54,7 +54,7 @@ private:
 		mFrame.Draw(mPge);
 
 		const olc::vi2d position = ToOLCVecInt(mFrame.GetContentOffset());
-		const int32_t scale = UITheme::kPixelScale;		
+                constexpr int32_t scale = UITheme::kPixelScale;
 
 		mPge.DrawSprite(position, &mFramebuffer, scale);
 	}

--- a/src/UI/Widgets/InstructionWidget.h
+++ b/src/UI/Widgets/InstructionWidget.h
@@ -30,9 +30,9 @@ public:
 		mFrame.Draw(mPge);		
 
 		const olc::vi2d offset = ToOLCVecInt(mFrame.GetContentOffset());
-		const int labelWidth = 10;
+                constexpr int labelWidth = 10;
 		const olc::Pixel textColor = viewModel.mIsDisplayInteractive ? olc::WHITE : olc::Pixel(192, 192, 192);  // White / Light Gray
-		const int lineHeight = UI_CHAR_SIZE;
+                constexpr int lineHeight = UI_CHAR_SIZE;
 
 		auto drawField = [&](int line, const std::string& label, const std::string& value) {
 			const olc::vi2d pos = offset + olc::vi2d{ 0, line * lineHeight };

--- a/src/UI/Widgets/RegisterWidget.h
+++ b/src/UI/Widgets/RegisterWidget.h
@@ -34,7 +34,7 @@ public:
 
 		const olc::vi2d offset = ToOLCVecInt(mFrame.GetContentOffset());
 		const olc::Pixel textColor = viewModel.mIsDisplayInteractive ? olc::WHITE : olc::Pixel(192, 192, 192);
-		const int lineHeight = UI_CHAR_SIZE;
+                constexpr int lineHeight = UI_CHAR_SIZE;
 
 		// Draw general-purpose registers V0-VF
 		for (uint8_t i = 0; i < REGISTER_COUNT; ++i)
@@ -50,7 +50,7 @@ public:
 			mPge.DrawString(pos, PadLeft(label, 3) + " " + value, textColor);
 		};
 
-		const int baseLine = REGISTER_COUNT + 1;
+                constexpr int baseLine = REGISTER_COUNT + 1;
 		drawField(baseLine + 0, "PC:", "0x" + ToHexString(state.mProgramCounter, 4));
 		drawField(baseLine + 1, "I:", "0x" + ToHexString(state.mIndexRegister, 4));
 		drawField(baseLine + 2, "SP:", "0x" + ToHexString(state.mStackPointer, 1));
@@ -61,7 +61,7 @@ public:
 private:
 	olc::vi2d GetInternalContentSize() const
 	{
-		const char* sample = "PC: 0x0200";  // Longest label + value string
+                constexpr const char* sample = "PC: 0x0200";  // Longest label + value string
 		return GetMonospaceStringBlockSize(sample, REGISTER_COUNT + 6);
 	}
 };

--- a/src/UI/Widgets/StackWidget.h
+++ b/src/UI/Widgets/StackWidget.h
@@ -30,7 +30,7 @@ public:
 		mFrame.Draw(mPge);		
 		
 		const olc::vi2d offset = ToOLCVecInt(mFrame.GetContentOffset());
-		const int32_t lineHeight = UI_CHAR_SIZE;
+                constexpr int32_t lineHeight = UI_CHAR_SIZE;
 
 		for (uint8_t i = 0; i < STACK_SIZE; ++i)
 		{


### PR DESCRIPTION
## Summary
- use `constexpr` for local arrays and simple constants
- propagate constexpr use through widgets and interpreter

## Testing
- `cmake -B build -S .` *(fails: unable to download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_6885b61edba4832fb114be85a90caff3